### PR TITLE
Proposed Change: Default to Mgd Id for all services if no RunAs Account exists

### DIFF
--- a/Connection.ps1
+++ b/Connection.ps1
@@ -1,7 +1,7 @@
 function getAutomationConnectionOrFromLocalCertificate([string] $AutomationConnectionName) {
     if ($RjRbRunningInAzure) {
         Write-RjRbLog "Getting automation connection '$AutomationConnectionName'"
-        return Get-AutomationConnection -Name $AutomationConnectionName
+        return (Get-AutomationConnection -Name $AutomationConnectionName -ErrorAction SilentlyContinue)
     }
     else {
         return devGetAutomationConnectionFromLocalCertificate -Name $AutomationConnectionName

--- a/ConnectionAz.ps1
+++ b/ConnectionAz.ps1
@@ -7,12 +7,13 @@ function Connect-RjRbAzAccount {
     # see RealmJoin.RunbookHelper.psm1
     $Global:VerbosePreference = "SilentlyContinue"
 
+    $autoCon = getAutomationConnectionOrFromLocalCertificate $AutomationConnectionName
     $connectParams = @{}
-    if (checkIfManagedIdentityShouldBeUsed 'AZ' $true) {
+    if ((-not $autoCon) -or (checkIfManagedIdentityShouldBeUsed 'AZ' $true)) {
         $connectParams += @{ Identity = $true }
     }
     else {
-        $connectParams += getAutomationConnectionOrFromLocalCertificate $AutomationConnectionName
+        $connectParams += $autoCon
     }
 
     Write-RjRbLog "Connecting with Az module" $connectParams

--- a/ConnectionExchangeOnline.ps1
+++ b/ConnectionExchangeOnline.ps1
@@ -7,12 +7,12 @@ function Connect-RjRbExchangeOnline {
     # see RealmJoin.RunbookHelper.psm1
     $Global:VerbosePreference = "SilentlyContinue"
 
+    $autoCon = getAutomationConnectionOrFromLocalCertificate $AutomationConnectionName
     $connectParams = @{ ShowBanner = $false }
-    if (checkIfManagedIdentityShouldBeUsed 'EXO' $false) {
+    if ((-not $autoCon) -or (checkIfManagedIdentityShouldBeUsed 'EXO' $false)) {
         $connectParams += @{ ManagedIdentity = $true }
     }
     else {
-        $autoCon = getAutomationConnectionOrFromLocalCertificate $AutomationConnectionName
         $connectParams += @{ 
             Organization          = $autoCon.TenantId
             AppId                 = $autoCon.ApplicationId

--- a/ConnectionOAuth2.ps1
+++ b/ConnectionOAuth2.ps1
@@ -55,12 +55,11 @@ function connectOAuth2Impl
         $Global:VerbosePreference = "SilentlyContinue"
 
         Write-RjRbLog "Requesting OAuth2 token for scope '$scope'"
-        if (checkIfManagedIdentityShouldBeUsed $serviceNameStub $true) {
+        $autoCon = getAutomationConnectionOrFromLocalCertificate $AutomationConnectionName
+        if ((-not $autoCon) -or (checkIfManagedIdentityShouldBeUsed $serviceNameStub $true)) {
             $tokenResult = requestOAuth2AccessTokenFromManagedIdentity -Scope $scope
         }
         else {
-            $autoCon = getAutomationConnectionOrFromLocalCertificate $AutomationConnectionName
-
             $certPsPath = "Cert:\CurrentUser\My\$($autoCon.CertificateThumbprint)"
             Write-RjRbLog "Getting certificate (and key) from '$certPsPath'"
             $cert = Get-Item $certPsPath


### PR DESCRIPTION
Proposed Change: Default to Mgd Id for all services if no RunAs Account exists - accross all services.
- Use Mgd Id if no RunAsAccount / Automation Connection exists
- Use RunAsAccount / Automation Connection if no Mgd Id exists
- Honor override via variables