### PR TITLE
Fix: Complex request bodies do not get translated to JSON

### DIFF
--- a/Logging.ps1
+++ b/Logging.ps1
@@ -40,10 +40,10 @@ function Write-RjRbLogImpl {
             $Message += ": "
         }
         if ($Data -is [Hashtable] -and $Data.Count -eq 1) {
-            $Message += "$($Data.Keys[0]): $($Data.Values[0] | ConvertTo-Json)"
+            $Message += "$($Data.Keys[0]): $($Data.Values[0] | ConvertTo-Json -Depth 20)"
         }
         else {
-            $Message += ($Data | ConvertTo-Json)
+            $Message += ($Data | ConvertTo-Json -Depth 20)
         }
     }
 

--- a/Rest.ps1
+++ b/Rest.ps1
@@ -166,7 +166,7 @@ function invokeRjRbRestMethodInternal {
     if ($JsonEncodeBody -and $Body -and (-not ($Body -is [byte[]] -or $Body -is [IO.Stream]))) {
         # need to explicetly set charset in ContentType for Invoke-RestMethod to detect it and to correctly encode JSON string
         $invokeArguments['ContentType'] = "application/json; charset=UTF-8"
-        $invokeArguments['Body'] = $Body | ConvertTo-Json
+        $invokeArguments['Body'] = $Body | ConvertTo-Json -Depth 20
     }
     if ($InFile -and -not $ContentType) {
         $invokeArguments['ContentType'] = [Web.MimeMapping]::GetMimeMapping($InFile)


### PR DESCRIPTION
Example: Sending eMail

$contentRaw = Get-Content -Path $ReportOutput -Raw 
    
if ($contentRaw) {
    $enc = [System.Text.Encoding]::Unicode
    $content = $enc.GetBytes($contentRaw)
    $contentBytes = [System.Convert]::ToBase64String($content)

    $message = @{
        subject     = "[Autom. erstellter Report] Team '$site' Shared Links"
        body        = @{
            contentType = "HTML"
            content     = @"
<p>Dies ist eine automatisch erstellte Mail.</p>
<h1>Team '$site' Sharing Links</h1>
<p>Im Anhang finden Sie eine &Uuml;bersicht &uuml;ber externe Sharing-Links in Team '$site'.</p> 
<p>Bitte pr&uuml;fen Sie, ob diese noch ben&ouml;tigt werden und entfernen Sie nicht ben&ouml;tigte Zugriffsrechte.</p>
<p>Danke!</p>
"@
        }
        attachments = [array]@{
            "@odata.type" = "#microsoft.graph.fileAttachment"
            name          = "excel.csv"
            contentType   = "text/plain"
            contentBytes  = $contentBytes
        }    
    }

    $message.toRecipients = @()
    
    $owners = Invoke-RjRbRestMethodGraph -Resource "/groups/$($groupId)/owners"
    if ($owners) {
        foreach ($owner in $owners) {
            $message.toRecipients += @{
                emailAddress = @{
                    address = $owner.Mail
                }
            }    
        }
    }
    else {
        $message.toRecipients += @{
            emailAddress = @{
                address = $failsafeRecipient
            }
        } 
    }
    
    Invoke-RjRbRestMethodGraph -Resource "/users/$fromUser/sendMail" -Method POST -Body @{ message = $message } | Out-Null
    "## Mail sent"

-> deeper elements like email-addresses will not be included in resulting JSON:
"toRecipients\": [\r\n \"System.Collections.Hashtable\"\r\n ]