### PR TITLE
Fix/Feature - Handle tokens that have been invalidated

### DIFF
--- a/Rest.ps1
+++ b/Rest.ps1
@@ -26,7 +26,21 @@ function Invoke-RjRbRestMethodGraph {
         $invokeArguments['Headers'] = $Script:RjRbGraphAuthHeaders
     }
 
-    Invoke-RjRbRestMethod -JsonEncodeBody @invokeArguments
+    try {
+        Invoke-RjRbRestMethod -JsonEncodeBody @invokeArguments
+    }
+    catch {
+        # Will handle invalidated tokens here, as this is specific to Graph
+        if ($_.Exception.Response.StatusCode -eq 401) {
+            Write-RjRbLog "Received 401 from Graph, requesting new token."
+            Connect-RjRbGraph -Force
+            $invokeArguments.Headers.Authorization = $Script:RjRbGraphAuthHeaders.Authorization
+            Invoke-RjRbRestMethod -JsonEncodeBody @invokeArguments
+        }
+        else {
+            throw $_
+        }
+    }
 }
 
 function Invoke-RjRbRestMethodDefenderATP {


### PR DESCRIPTION
Handle Tokens that have been invalidated (but were initially authenticated). As we don't use refresh tokens, I simply request a fresh token.