### PR TITLE
Add Register-PSResourceRepository step to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
+          Register-PSResourceRepository -PSGallery -Trusted
           $dst = Join-Path $env:RUNNER_TEMP 'RealmJoin.RunbookHelper'
           New-Item -ItemType Directory -Path $dst | Out-Null
           Copy-Item *.ps1, *.psd1, *.psm1 $dst


### PR DESCRIPTION
This pull request makes a small update to the deployment workflow by ensuring that the PowerShell Gallery is registered as a trusted resource before proceeding with the build steps.

- Workflow improvement:
  * Added a step to register the PowerShell Gallery as a trusted resource using `Register-PSResourceRepository -PSGallery -Trusted` in the `.github/workflows/publish.yml` file.