### PR TITLE
Fix formatting issues and add Excel report generation function

### DIFF
--- a/ExcelReport.ps1
+++ b/ExcelReport.ps1
@@ -1,0 +1,626 @@
+# Windows PowerShell 5.1 does not load System.IO.Compression by default; a no-op on PowerShell 7+.
+if ($PSVersionTable.PSVersion.Major -le 5) {
+    Add-Type -AssemblyName System.IO.Compression
+}
+
+function Export-RjRbXlsx {
+    <#
+        .SYNOPSIS
+        Exports objects to an Excel workbook (.xlsx) without external module dependencies.
+
+        .DESCRIPTION
+        Writes one or more tables of PSCustomObjects as a native Excel workbook using only
+        .NET (System.IO.Compression). Each worksheet gets a styled Excel table (navy header,
+        zebra rows that follow re-sorting, filter dropdowns), a frozen header row, calculated
+        column widths and an automatic print setup (orientation from content width, header
+        row repeated per page).
+
+        Cell values keep their type: .NET numbers become Excel numbers, DateTime/DateTimeOffset
+        values and ISO-8601 strings become real Excel dates (localized by the client; dates
+        before 1900 stay text since Excel cannot render them), http/https URLs
+        become clickable hyperlinks (disable with -NoHyperlink). All other strings stay text -
+        values like serial numbers or IMEIs are never converted to numbers, and formula
+        injection is not possible.
+
+        .PARAMETER InputObject
+        The rows to export (array of objects; also accepted via pipeline). Column order
+        follows the property order of the first object.
+
+        .PARAMETER Path
+        Full path of the .xlsx file to create. An existing file is overwritten.
+
+        .PARAMETER WorksheetName
+        Name of the single worksheet (default: "Report").
+
+        .PARAMETER Worksheets
+        Ordered dictionary of worksheet name -> rows for a workbook with multiple worksheets,
+        e.g. ([ordered]@{ 'Summary' = $summary; 'Details' = $details }).
+
+        .PARAMETER NoHyperlink
+        Do not convert http/https URL strings into clickable hyperlinks.
+
+        .PARAMETER HighlightRules
+        Optional conditional formatting rules for status columns. Array of hashtables (or
+        objects) with Column (header name), Value (exact cell text, case-insensitive) and Color
+        ('Green', 'Red' or 'Yellow' - the classic Excel highlight presets), e.g.
+        @( @{ Column = 'InIntune'; Value = 'yes'; Color = 'Green' },
+           @{ Column = 'InIntune'; Value = 'no';  Color = 'Red' } )
+        Rules are applied on every worksheet that contains the named column.
+
+        .PARAMETER CoverSheet
+        Optional ordered dictionary rendered as an "Info" cover worksheet (first tab):
+        a 'Title' key becomes the heading, all other keys become label/value rows, e.g.
+        ([ordered]@{ Title = 'Device Report'; Tenant = 'contoso'; Generated = '2026-07-16 08:00 UTC' })
+
+        .PARAMETER HyperlinkText
+        Optional dictionary of column name -> display text for hyperlink cells, e.g.
+        @{ Portal = 'Open in Intune' }. The cell shows the friendly text, the link target
+        stays the full URL. Columns without a mapping keep showing the URL.
+
+        .PARAMETER HideGridLines
+        Hide the worksheet grid lines outside the table. Off by default (grid lines help
+        readability); the cover sheet always hides them.
+
+        .PARAMETER UseThousandsSeparator
+        Format numeric cells with a thousands separator (#,##0 for integers, #,##0.00 for
+        decimals, localized by Excel). Off by default.
+
+        .PARAMETER DataBarColumns
+        Optional list of numeric column names that get an in-cell data bar (orange,
+        min-to-max gradient), e.g. @('DeviceCount'). Lets outliers stand out at a glance
+        while the cells stay sortable and filterable. Columns that do not exist on a
+        worksheet are skipped.
+
+        .EXAMPLE
+        PS C:\> $devices | Export-RjRbXlsx -Path report.xlsx -WorksheetName 'Devices'
+
+        .EXAMPLE
+        PS C:\> Export-RjRbXlsx -Worksheets ([ordered]@{ Summary = $sum; Details = $det }) -Path report.xlsx
+
+        .EXAMPLE
+        PS C:\> Export-RjRbXlsx -Worksheets ([ordered]@{ Devices = $devices }) -Path report.xlsx `
+                    -CoverSheet ([ordered]@{ Title = 'Device Report'; Tenant = $tenantName }) `
+                    -HighlightRules @( @{ Column = 'Compliant'; Value = 'no'; Color = 'Red' } ) `
+                    -DataBarColumns @('DeviceCount')
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'SingleSheet')]
+    param(
+        [Parameter(ParameterSetName = 'SingleSheet', ValueFromPipeline = $true)]
+        [object[]]$InputObject,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(ParameterSetName = 'SingleSheet')]
+        [string]$WorksheetName = 'Report',
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'MultiSheet')]
+        [System.Collections.IDictionary]$Worksheets,
+
+        [switch]$NoHyperlink,
+
+        [object[]]$HighlightRules,
+
+        [System.Collections.IDictionary]$CoverSheet,
+
+        [System.Collections.IDictionary]$HyperlinkText,
+
+        [switch]$HideGridLines,
+
+        [switch]$UseThousandsSeparator,
+
+        [object[]]$DataBarColumns
+    )
+
+    begin {
+        $pipelineRows = [System.Collections.Generic.List[object]]::new()
+
+        $invariant = [System.Globalization.CultureInfo]::InvariantCulture
+
+        function ConvertTo-XlsxXmlText {
+            param([string]$Text)
+            # Strip control characters that are invalid in XML 1.0 (keep tab/LF/CR), then escape
+            $sb = [System.Text.StringBuilder]::new($Text.Length)
+            foreach ($ch in $Text.ToCharArray()) {
+                $code = [int]$ch
+                if ($code -lt 32 -and $code -ne 9 -and $code -ne 10 -and $code -ne 13) { continue }
+                switch ($ch) {
+                    '&' { [void]$sb.Append('&amp;') }
+                    '<' { [void]$sb.Append('&lt;') }
+                    '>' { [void]$sb.Append('&gt;') }
+                    '"' { [void]$sb.Append('&quot;') }
+                    default { [void]$sb.Append($ch) }
+                }
+            }
+            $sb.ToString()
+        }
+
+        function ConvertTo-XlsxColumnName {
+            param([int]$Index) # 1-based
+            $name = ''
+            while ($Index -gt 0) {
+                $Index--
+                $name = [char](65 + ($Index % 26)) + $name
+                $Index = [int][math]::Floor($Index / 26)
+            }
+            $name
+        }
+
+        function Get-XlsxSheetName {
+            param([string]$Name, [int]$Number, [System.Collections.Generic.HashSet[string]]$Used)
+            $clean = ($Name -replace '[\[\]:*?/\\]', ' ').Trim().Trim("'")
+            if (-not $clean) { $clean = "Sheet$Number" }
+            if ($clean.Length -gt 31) { $clean = $clean.Substring(0, 31).Trim() }
+            $candidate = $clean
+            $suffix = 2
+            while (-not $Used.Add($candidate)) {
+                $tail = "_$suffix"
+                $candidate = $clean.Substring(0, [math]::Min($clean.Length, 31 - $tail.Length)) + $tail
+                $suffix++
+            }
+            $candidate
+        }
+
+        function Find-XlsxColumnIndex {
+            param([string[]]$Headers, [string]$Name) # returns -1 when not found
+            for ($i = 0; $i -lt $Headers.Count; $i++) {
+                if ($Headers[$i] -eq $Name) { return $i }
+            }
+            return -1
+        }
+
+        function New-XlsxDateCell {
+            param([datetime]$Value, [string]$CellRef, [System.Globalization.CultureInfo]$Invariant)
+            # Excel cannot render date serials below 1 (before 1900; DateTime.MinValue maps
+            # to serial 0 which Excel shows as the bogus "1/0/1900") - fall back to text
+            $oaDate = $Value.ToOADate()
+            if ($oaDate -lt 1) {
+                $text = if ($Value.TimeOfDay -eq [timespan]::Zero) { $Value.ToString('yyyy-MM-dd', $Invariant) }
+                else { $Value.ToString('yyyy-MM-dd HH:mm:ss', $Invariant) }
+                [pscustomobject]@{ Xml = "<c r=""$CellRef"" t=""inlineStr""><is><t>$text</t></is></c>"; Length = $text.Length }
+            }
+            else {
+                $style = if ($Value.TimeOfDay -eq [timespan]::Zero) { 1 } else { 2 }
+                [pscustomobject]@{ Xml = "<c r=""$CellRef"" s=""$style""><v>$($oaDate.ToString($Invariant))</v></c>"; Length = 17 }
+            }
+        }
+
+        function Get-XlsxRuleProperty {
+            param($Rule, [string]$Name) # tolerates hashtables and objects with missing members
+            if ($Rule -is [System.Collections.IDictionary]) { return $Rule[$Name] }
+            $prop = $Rule.PSObject.Properties[$Name]
+            if ($prop) { return $prop.Value }
+            return $null
+        }
+    }
+
+    process {
+        if ($PSCmdlet.ParameterSetName -eq 'SingleSheet' -and $null -ne $InputObject) {
+            foreach ($item in $InputObject) { $pipelineRows.Add($item) }
+        }
+    }
+
+    end {
+        # Normalize both parameter sets into an ordered list of (Name, Rows); dictionaries become objects
+        $normalizeRows = {
+            param($Rows)
+            @($Rows) | Where-Object { $null -ne $_ } | ForEach-Object {
+                if ($_ -is [System.Collections.IDictionary]) { [pscustomobject]$_ } else { $_ }
+            }
+        }
+        $sheetDefs = [System.Collections.Generic.List[object]]::new()
+        if ($PSCmdlet.ParameterSetName -eq 'MultiSheet') {
+            foreach ($key in $Worksheets.Keys) {
+                $sheetDefs.Add([pscustomobject]@{ Name = [string]$key; Rows = @(& $normalizeRows $Worksheets[$key]); IsCover = $false })
+            }
+            if ($sheetDefs.Count -eq 0) { throw "Export-RjRbXlsx: -Worksheets must contain at least one entry." }
+        }
+        else {
+            $sheetDefs.Add([pscustomobject]@{ Name = $WorksheetName; Rows = @(& $normalizeRows $pipelineRows); IsCover = $false })
+        }
+        if ($CoverSheet) {
+            $sheetDefs.Insert(0, [pscustomobject]@{ Name = 'Info'; Rows = @(); IsCover = $true })
+        }
+
+        $usedSheetNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+        $xmlDecl = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        $mainNs = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main'
+        $relNs = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'
+        $pkgRelNs = 'http://schemas.openxmlformats.org/package/2006/relationships'
+        $maxDataRows = 1048575 # xlsx row limit (1,048,576) minus header row
+        $isoDateRegex = [regex]'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'
+
+        # Resolve PSProvider-relative paths; [System.IO.File] would otherwise resolve
+        # against the process working directory instead of the PowerShell location.
+        $resolvedPath = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($Path)
+        if (Test-Path -LiteralPath $resolvedPath) { Remove-Item -LiteralPath $resolvedPath -Force }
+        $fileStream = [System.IO.File]::Open($resolvedPath, [System.IO.FileMode]::CreateNew)
+        try {
+            $zip = [System.IO.Compression.ZipArchive]::new($fileStream, [System.IO.Compression.ZipArchiveMode]::Create)
+            try {
+                $writeEntry = {
+                    param([string]$EntryName, [string]$Content)
+                    $entry = $zip.CreateEntry($EntryName, [System.IO.Compression.CompressionLevel]::Optimal)
+                    $writer = [System.IO.StreamWriter]::new($entry.Open(), $utf8NoBom)
+                    try { $writer.Write($Content) } finally { $writer.Dispose() }
+                }
+
+                #region Static package parts
+                $contentTypes = [System.Text.StringBuilder]::new()
+                [void]$contentTypes.Append("$xmlDecl<Types xmlns=""http://schemas.openxmlformats.org/package/2006/content-types"">")
+                [void]$contentTypes.Append('<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>')
+                [void]$contentTypes.Append('<Default Extension="xml" ContentType="application/xml"/>')
+                [void]$contentTypes.Append('<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>')
+                [void]$contentTypes.Append('<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>')
+                for ($s = 1; $s -le $sheetDefs.Count; $s++) {
+                    [void]$contentTypes.Append("<Override PartName=""/xl/worksheets/sheet$s.xml"" ContentType=""application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml""/>")
+                }
+                # table overrides are appended while writing the sheets (empty sheets have no table)
+
+                & $writeEntry '_rels/.rels' ("$xmlDecl<Relationships xmlns=""$pkgRelNs"">" +
+                    "<Relationship Id=""rId1"" Type=""$relNs/officeDocument"" Target=""xl/workbook.xml""/>" +
+                    '</Relationships>')
+
+                # Workbook + workbook relationships
+                $workbook = [System.Text.StringBuilder]::new()
+                [void]$workbook.Append("$xmlDecl<workbook xmlns=""$mainNs"" xmlns:r=""$relNs""><sheets>")
+                $workbookRels = [System.Text.StringBuilder]::new()
+                [void]$workbookRels.Append("$xmlDecl<Relationships xmlns=""$pkgRelNs"">")
+                $sheetNames = @()
+                for ($s = 1; $s -le $sheetDefs.Count; $s++) {
+                    $sheetName = Get-XlsxSheetName -Name $sheetDefs[$s - 1].Name -Number $s -Used $usedSheetNames
+                    $sheetNames += $sheetName
+                    [void]$workbook.Append("<sheet name=""$(ConvertTo-XlsxXmlText $sheetName)"" sheetId=""$s"" r:id=""rId$s""/>")
+                    [void]$workbookRels.Append("<Relationship Id=""rId$s"" Type=""$relNs/worksheet"" Target=""worksheets/sheet$s.xml""/>")
+                }
+                [void]$workbook.Append('</sheets>')
+                # Repeat the header row on every printed page (skipped for the cover sheet)
+                $printTitles = ''
+                for ($s = 1; $s -le $sheetDefs.Count; $s++) {
+                    if ($sheetDefs[$s - 1].IsCover) { continue }
+                    $quotedName = ConvertTo-XlsxXmlText ($sheetNames[$s - 1] -replace "'", "''")
+                    $printTitles += '<definedName name="_xlnm.Print_Titles" localSheetId="' + ($s - 1) + '">&apos;' + $quotedName + '&apos;!$1:$1</definedName>'
+                }
+                if ($printTitles) { [void]$workbook.Append("<definedNames>$printTitles</definedNames>") }
+                [void]$workbook.Append('</workbook>')
+                [void]$workbookRels.Append("<Relationship Id=""rId$($sheetDefs.Count + 1)"" Type=""$relNs/styles"" Target=""styles.xml""/>")
+                [void]$workbookRels.Append('</Relationships>')
+                & $writeEntry 'xl/workbook.xml' $workbook.ToString()
+                & $writeEntry 'xl/_rels/workbook.xml.rels' $workbookRels.ToString()
+
+                # Styles. Fonts: 0=default, 1=hyperlink, 2=cover title, 3=cover label.
+                # cellXfs: 0=default, 1=date, 2=datetime, 3=hyperlink, 4=int grouped, 5=decimal grouped,
+                #          6=cover title (orange accent border), 7=cover accent line, 8=cover label
+                & $writeEntry 'xl/styles.xml' ("$xmlDecl<styleSheet xmlns=""$mainNs"">" +
+                    '<fonts count="4">' +
+                    '<font><sz val="12"/><name val="Calibri"/><family val="2"/></font>' +
+                    '<font><u/><sz val="12"/><color rgb="FF0563C1"/><name val="Calibri"/><family val="2"/></font>' +
+                    '<font><b/><sz val="18"/><color rgb="FF1B2A44"/><name val="Calibri"/><family val="2"/></font>' +
+                    '<font><b/><sz val="12"/><color rgb="FF595959"/><name val="Calibri"/><family val="2"/></font>' +
+                    '</fonts>' +
+                    '<fills count="2"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill></fills>' +
+                    '<borders count="2">' +
+                    '<border><left/><right/><top/><bottom/><diagonal/></border>' +
+                    '<border><left/><right/><top/><bottom style="thick"><color rgb="FFF0871E"/></bottom><diagonal/></border>' +
+                    '</borders>' +
+                    '<cellStyleXfs count="2"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/><xf numFmtId="0" fontId="1" fillId="0" borderId="0"/></cellStyleXfs>' +
+                    '<cellXfs count="9">' +
+                    '<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>' +
+                    '<xf numFmtId="14" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>' +
+                    '<xf numFmtId="22" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>' +
+                    '<xf numFmtId="0" fontId="1" fillId="0" borderId="0" xfId="1" applyFont="1"/>' +
+                    '<xf numFmtId="3" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>' +
+                    '<xf numFmtId="4" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>' +
+                    '<xf numFmtId="0" fontId="2" fillId="0" borderId="1" xfId="0" applyFont="1" applyBorder="1"/>' +
+                    '<xf numFmtId="0" fontId="0" fillId="0" borderId="1" xfId="0" applyBorder="1"/>' +
+                    '<xf numFmtId="0" fontId="3" fillId="0" borderId="0" xfId="0" applyFont="1"/>' +
+                    '</cellXfs>' +
+                    '<cellStyles count="2"><cellStyle name="Normal" xfId="0" builtinId="0"/><cellStyle name="Hyperlink" xfId="1" builtinId="8"/></cellStyles>' +
+                    # dxf 0-2 = classic Excel highlight presets green/red/yellow (used by -HighlightRules),
+                    # dxf 3-5 = custom table style: navy header, zebra stripe, explicit white second stripe
+                    # (white second stripe covers the grid lines inside the table; banding follows re-sorting)
+                    '<dxfs count="6">' +
+                    '<dxf><font><color rgb="FF006100"/></font><fill><patternFill><bgColor rgb="FFC6EFCE"/></patternFill></fill></dxf>' +
+                    '<dxf><font><color rgb="FF9C0006"/></font><fill><patternFill><bgColor rgb="FFFFC7CE"/></patternFill></fill></dxf>' +
+                    '<dxf><font><color rgb="FF9C6500"/></font><fill><patternFill><bgColor rgb="FFFFEB9C"/></patternFill></fill></dxf>' +
+                    '<dxf><font><b/><color rgb="FFFFFFFF"/></font><fill><patternFill><bgColor rgb="FF1B2A44"/></patternFill></fill></dxf>' +
+                    '<dxf><fill><patternFill><bgColor rgb="FFDEE4EE"/></patternFill></fill></dxf>' +
+                    '<dxf><fill><patternFill><bgColor rgb="FFFFFFFF"/></patternFill></fill></dxf>' +
+                    '</dxfs>' +
+                    '<tableStyles count="1" defaultTableStyle="TableStyleMedium2" defaultPivotStyle="PivotStyleLight16">' +
+                    '<tableStyle name="RjRbReport" pivot="0" count="3">' +
+                    '<tableStyleElement type="headerRow" dxfId="3"/>' +
+                    '<tableStyleElement type="firstRowStripe" dxfId="4"/>' +
+                    '<tableStyleElement type="secondRowStripe" dxfId="5"/>' +
+                    '</tableStyle></tableStyles>' +
+                    '</styleSheet>')
+                #endregion
+
+                #region Worksheets
+                for ($s = 1; $s -le $sheetDefs.Count; $s++) {
+                    # First tab in RealmJoin orange, remaining tabs in neutral gray
+                    $tabColorRgb = if ($s -eq 1) { 'FFF0871E' } else { 'FF7F7F7F' }
+
+                    # Cover sheet: title + label/value rows, no table, no grid lines
+                    if ($sheetDefs[$s - 1].IsCover) {
+                        $coverTitle = if ($CoverSheet.Contains('Title')) { [string]$CoverSheet['Title'] } else { 'Report' }
+                        $coverKeys = @($CoverSheet.Keys | Where-Object { [string]$_ -ne 'Title' })
+                        $cover = [System.Text.StringBuilder]::new()
+                        [void]$cover.Append("$xmlDecl<worksheet xmlns=""$mainNs"" xmlns:r=""$relNs"">")
+                        [void]$cover.Append("<sheetPr><tabColor rgb=""$tabColorRgb""/></sheetPr>")
+                        [void]$cover.Append("<dimension ref=""A1:C$($coverKeys.Count + 4)""/>")
+                        [void]$cover.Append('<sheetViews><sheetView workbookViewId="0" showGridLines="0"/></sheetViews>')
+                        # Narrow spacer column A indents the content away from the sheet edge
+                        [void]$cover.Append('<cols><col min="1" max="1" width="3.6" customWidth="1"/><col min="2" max="2" width="26" customWidth="1"/><col min="3" max="3" width="48" customWidth="1"/></cols>')
+                        [void]$cover.Append('<sheetData>')
+                        # Title in row 3: navy heading with an orange accent line spanning both content columns
+                        [void]$cover.Append("<row r=""3"" ht=""30"" customHeight=""1""><c r=""B3"" s=""6"" t=""inlineStr""><is><t>$(ConvertTo-XlsxXmlText $coverTitle)</t></is></c><c r=""C3"" s=""7""/></row>")
+                        $coverRow = 4
+                        foreach ($coverKey in $coverKeys) {
+                            $coverRow++
+                            $labelXml = ConvertTo-XlsxXmlText ([string]$coverKey)
+                            $valueXml = ConvertTo-XlsxXmlText ([string]$CoverSheet[$coverKey])
+                            [void]$cover.Append("<row r=""$coverRow"" ht=""20"" customHeight=""1""><c r=""B$coverRow"" s=""8"" t=""inlineStr""><is><t>$labelXml</t></is></c><c r=""C$coverRow"" t=""inlineStr""><is><t>$valueXml</t></is></c></row>")
+                        }
+                        [void]$cover.Append('</sheetData></worksheet>')
+                        & $writeEntry "xl/worksheets/sheet$s.xml" $cover.ToString()
+                        continue
+                    }
+
+                    $rows = @($sheetDefs[$s - 1].Rows | Where-Object { $null -ne $_ })
+                    if ($rows.Count -gt $maxDataRows) {
+                        throw "Export-RjRbXlsx: worksheet '$($sheetNames[$s - 1])' has $($rows.Count) rows - the xlsx limit is $maxDataRows data rows."
+                    }
+
+                    # Header names from the property order of the first object, deduplicated (table columns must be unique and non-empty)
+                    $headers = @()
+                    if ($rows.Count -gt 0) {
+                        $seenHeaders = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                        $col = 0
+                        foreach ($prop in $rows[0].PSObject.Properties.Name) {
+                            $col++
+                            $name = if ([string]::IsNullOrWhiteSpace($prop)) { "Column$col" } else { $prop }
+                            $suffix = 2
+                            $candidate = $name
+                            while (-not $seenHeaders.Add($candidate)) { $candidate = "${name}_$suffix"; $suffix++ }
+                            $headers += $candidate
+                        }
+                    }
+
+                    # Empty worksheet: single info cell, no table
+                    if ($headers.Count -eq 0) {
+                        & $writeEntry "xl/worksheets/sheet$s.xml" ("$xmlDecl<worksheet xmlns=""$mainNs"" xmlns:r=""$relNs"">" +
+                            "<sheetPr><tabColor rgb=""$tabColorRgb""/></sheetPr>" +
+                            '<dimension ref="A1:A1"/><sheetViews><sheetView workbookViewId="0"/></sheetViews>' +
+                            '<sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>No data available</t></is></c></row></sheetData>' +
+                            '</worksheet>')
+                        continue
+                    }
+
+                    [void]$contentTypes.Append("<Override PartName=""/xl/tables/table$s.xml"" ContentType=""application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml""/>")
+
+                    $colCount = $headers.Count
+                    $propNames = @($rows[0].PSObject.Properties.Name)
+                    $colNames = @(1..$colCount | ForEach-Object { ConvertTo-XlsxColumnName $_ })
+                    $lastColName = $colNames[$colCount - 1]
+                    $lastRow = $rows.Count + 1
+                    $tableRef = "A1:$lastColName$lastRow"
+
+                    # Pre-compute cell descriptors and column widths (widths from the first 1000 rows)
+                    $widths = @($headers | ForEach-Object { $_.Length + 3 }) # + filter dropdown button
+                    $cellMatrix = [System.Collections.Generic.List[object]]::new()
+                    $hyperlinks = [System.Collections.Generic.List[object]]::new()
+                    $rowIndex = 1
+                    foreach ($row in $rows) {
+                        $rowIndex++
+                        $cells = [System.Collections.Generic.List[string]]::new()
+                        for ($c = 1; $c -le $colCount; $c++) {
+                            $propInfo = $row.PSObject.Properties[$propNames[$c - 1]]
+                            $value = if ($propInfo) { $propInfo.Value } else { $null }
+                            $cellRef = "$($colNames[$c - 1])$rowIndex"
+                            $displayLength = 0
+                            $cellXml = $null
+
+                            if ($null -eq $value -or $value -is [System.DBNull]) {
+                                $cells.Add('')
+                                continue
+                            }
+
+                            # DateTimeOffset (e.g. from Graph SDK models) is treated like DateTime, normalized to UTC
+                            if ($value -is [System.DateTimeOffset]) { $value = $value.UtcDateTime }
+
+                            $typeCode = if ($value -is [string]) { [System.TypeCode]::String } else { [System.Type]::GetTypeCode($value.GetType()) }
+
+                            if ($value -is [datetime]) {
+                                $dateCell = New-XlsxDateCell -Value $value -CellRef $cellRef -Invariant $invariant
+                                $cellXml = $dateCell.Xml
+                                $displayLength = $dateCell.Length
+                            }
+                            elseif ($value -is [bool]) {
+                                $cellXml = "<c r=""$cellRef"" t=""b""><v>$(if ($value) { 1 } else { 0 })</v></c>"
+                                $displayLength = 5
+                            }
+                            elseif ($typeCode -in @(
+                                    [System.TypeCode]::Byte, [System.TypeCode]::SByte, [System.TypeCode]::Int16, [System.TypeCode]::UInt16,
+                                    [System.TypeCode]::Int32, [System.TypeCode]::UInt32, [System.TypeCode]::Int64, [System.TypeCode]::UInt64,
+                                    [System.TypeCode]::Single, [System.TypeCode]::Double, [System.TypeCode]::Decimal)) {
+                                $numText = [string]$value.ToString($invariant)
+                                if ($numText -match '^(NaN|.*Infinity)$') {
+                                    $escaped = ConvertTo-XlsxXmlText $numText
+                                    $cellXml = "<c r=""$cellRef"" t=""inlineStr""><is><t>$escaped</t></is></c>"
+                                }
+                                else {
+                                    $numStyle = ''
+                                    if ($UseThousandsSeparator) {
+                                        $isDecimalType = $typeCode -in @([System.TypeCode]::Single, [System.TypeCode]::Double, [System.TypeCode]::Decimal)
+                                        $numStyle = if ($isDecimalType) { ' s="5"' } else { ' s="4"' }
+                                    }
+                                    $cellXml = "<c r=""$cellRef""$numStyle><v>$numText</v></c>"
+                                }
+                                $displayLength = $numText.Length
+                            }
+                            else {
+                                # Everything else is rendered as text (arrays joined, objects stringified)
+                                $text = if ($value -is [string]) { $value }
+                                elseif ($value -is [System.Collections.IEnumerable]) { @($value | ForEach-Object { [string]$_ }) -join '; ' }
+                                else { [string]$value }
+
+                                $parsedDate = [datetime]::MinValue
+                                if ($isoDateRegex.IsMatch($text) -and [datetime]::TryParse($text, $invariant,
+                                        [System.Globalization.DateTimeStyles]::AdjustToUniversal, [ref]$parsedDate)) {
+                                    # ISO-8601 strings (Graph date fields) become real, sortable Excel dates
+                                    $dateCell = New-XlsxDateCell -Value $parsedDate -CellRef $cellRef -Invariant $invariant
+                                    $cellXml = $dateCell.Xml
+                                    $displayLength = $dateCell.Length
+                                }
+                                else {
+                                    $escaped = ConvertTo-XlsxXmlText $text
+                                    $preserve = if ($text -match '^\s|\s$') { ' xml:space="preserve"' } else { '' }
+                                    $isUrl = (-not $NoHyperlink) -and $text -match '^https?://' -and
+                                        [System.Uri]::IsWellFormedUriString($text, [System.UriKind]::Absolute)
+                                    if ($isUrl) {
+                                        # Optional friendly display text per column; the link target stays the full URL
+                                        $display = $text
+                                        if ($HyperlinkText -and $HyperlinkText.Contains($propNames[$c - 1]) -and $HyperlinkText[$propNames[$c - 1]]) {
+                                            $display = [string]$HyperlinkText[$propNames[$c - 1]]
+                                        }
+                                        $escapedDisplay = ConvertTo-XlsxXmlText $display
+                                        $cellXml = "<c r=""$cellRef"" s=""3"" t=""inlineStr""><is><t>$escapedDisplay</t></is></c>"
+                                        $hyperlinks.Add([pscustomobject]@{ Ref = $cellRef; Url = $text })
+                                        $displayLength = $display.Length
+                                    }
+                                    else {
+                                        $cellXml = "<c r=""$cellRef"" t=""inlineStr""><is><t$preserve>$escaped</t></is></c>"
+                                        $displayLength = $text.Length
+                                    }
+                                }
+                            }
+
+                            $cells.Add($cellXml)
+                            if ($rowIndex -le 1001 -and $displayLength -gt $widths[$c - 1]) { $widths[$c - 1] = $displayLength }
+                        }
+                        $cellMatrix.Add($cells)
+                    }
+
+                    # Worksheet XML (schema order: sheetPr, dimension, sheetViews, cols, sheetData,
+                    # conditionalFormatting, hyperlinks, pageMargins, pageSetup, tableParts)
+                    $sheet = [System.Text.StringBuilder]::new()
+                    [void]$sheet.Append("$xmlDecl<worksheet xmlns=""$mainNs"" xmlns:r=""$relNs"">")
+                    [void]$sheet.Append("<sheetPr><tabColor rgb=""$tabColorRgb""/><pageSetUpPr fitToPage=""1""/></sheetPr>")
+                    [void]$sheet.Append("<dimension ref=""$tableRef""/>")
+                    $gridLinesAttr = if ($HideGridLines) { ' showGridLines="0"' } else { '' }
+                    [void]$sheet.Append("<sheetViews><sheetView workbookViewId=""0""$gridLinesAttr><pane ySplit=""1"" topLeftCell=""A2"" activePane=""bottomLeft"" state=""frozen""/></sheetView></sheetViews>")
+                    [void]$sheet.Append('<cols>')
+                    $totalWidth = 0
+                    for ($c = 1; $c -le $colCount; $c++) {
+                        $width = [math]::Min([math]::Max($widths[$c - 1] + 2, 8), 60)
+                        $totalWidth += $width
+                        [void]$sheet.Append("<col min=""$c"" max=""$c"" width=""$width"" customWidth=""1""/>")
+                    }
+                    [void]$sheet.Append('</cols><sheetData>')
+
+                    # Header row: no explicit cell style, so the table style fully controls the header look
+                    [void]$sheet.Append('<row r="1">')
+                    for ($c = 1; $c -le $colCount; $c++) {
+                        $escaped = ConvertTo-XlsxXmlText $headers[$c - 1]
+                        [void]$sheet.Append("<c r=""$($colNames[$c - 1])1"" t=""inlineStr""><is><t>$escaped</t></is></c>")
+                    }
+                    [void]$sheet.Append('</row>')
+
+                    $rowIndex = 1
+                    foreach ($cells in $cellMatrix) {
+                        $rowIndex++
+                        [void]$sheet.Append("<row r=""$rowIndex"">")
+                        foreach ($cellXml in $cells) { if ($cellXml) { [void]$sheet.Append($cellXml) } }
+                        [void]$sheet.Append('</row>')
+                    }
+                    [void]$sheet.Append('</sheetData>')
+
+                    # Conditional formatting: status-column highlights and in-cell data bars
+                    if (($HighlightRules -or $DataBarColumns) -and $rows.Count -gt 0) {
+                        $dxfIds = @{ 'green' = 0; 'red' = 1; 'yellow' = 2 }
+                        $priority = 1
+                        foreach ($rule in @($HighlightRules)) {
+                            $ruleColumn = [string](Get-XlsxRuleProperty -Rule $rule -Name 'Column')
+                            $ruleColor = [string](Get-XlsxRuleProperty -Rule $rule -Name 'Color')
+                            $colIndex = Find-XlsxColumnIndex -Headers $headers -Name $ruleColumn
+                            if ($colIndex -lt 0) { continue }
+                            $colorKey = $ruleColor.ToLowerInvariant()
+                            if (-not $dxfIds.ContainsKey($colorKey)) {
+                                Write-Warning "Export-RjRbXlsx: unknown highlight color '$ruleColor' - use Green, Red or Yellow. Skipping rule."
+                                continue
+                            }
+                            $colName = $colNames[$colIndex]
+                            $escapedValue = ConvertTo-XlsxXmlText ([string](Get-XlsxRuleProperty -Rule $rule -Name 'Value'))
+                            [void]$sheet.Append("<conditionalFormatting sqref=""${colName}2:$colName$lastRow"">")
+                            [void]$sheet.Append("<cfRule type=""cellIs"" dxfId=""$($dxfIds[$colorKey])"" priority=""$priority"" operator=""equal""><formula>&quot;$escapedValue&quot;</formula></cfRule>")
+                            [void]$sheet.Append('</conditionalFormatting>')
+                            $priority++
+                        }
+                        foreach ($dataBarColumn in @($DataBarColumns)) {
+                            $colIndex = Find-XlsxColumnIndex -Headers $headers -Name ([string]$dataBarColumn)
+                            if ($colIndex -lt 0) { continue }
+                            $colName = $colNames[$colIndex]
+                            [void]$sheet.Append("<conditionalFormatting sqref=""${colName}2:$colName$lastRow"">")
+                            [void]$sheet.Append("<cfRule type=""dataBar"" priority=""$priority""><dataBar><cfvo type=""min""/><cfvo type=""max""/><color rgb=""FFF0871E""/></dataBar></cfRule>")
+                            [void]$sheet.Append('</conditionalFormatting>')
+                            $priority++
+                        }
+                    }
+
+                    if ($hyperlinks.Count -gt 0) {
+                        [void]$sheet.Append('<hyperlinks>')
+                        $linkId = 1
+                        foreach ($link in $hyperlinks) {
+                            $linkId++
+                            [void]$sheet.Append("<hyperlink ref=""$($link.Ref)"" r:id=""rId$linkId""/>")
+                        }
+                        [void]$sheet.Append('</hyperlinks>')
+                    }
+                    # Print setup: orientation derived from content width, scale to one page wide
+                    $orientation = if ($totalWidth -gt 110) { 'landscape' } else { 'portrait' }
+                    [void]$sheet.Append('<pageMargins left="0.7" right="0.7" top="0.75" bottom="0.75" header="0.3" footer="0.3"/>')
+                    [void]$sheet.Append("<pageSetup orientation=""$orientation"" fitToWidth=""1"" fitToHeight=""0""/>")
+                    [void]$sheet.Append('<tableParts count="1"><tablePart r:id="rId1"/></tableParts>')
+                    [void]$sheet.Append('</worksheet>')
+                    & $writeEntry "xl/worksheets/sheet$s.xml" $sheet.ToString()
+
+                    # Table part: filter dropdowns; header and banding come from the custom RjRbReport style
+                    $table = [System.Text.StringBuilder]::new()
+                    [void]$table.Append("$xmlDecl<table xmlns=""$mainNs"" id=""$s"" name=""Table$s"" displayName=""Table$s"" ref=""$tableRef"" headerRowCount=""1"">")
+                    [void]$table.Append("<autoFilter ref=""$tableRef""/><tableColumns count=""$colCount"">")
+                    for ($c = 1; $c -le $colCount; $c++) {
+                        [void]$table.Append("<tableColumn id=""$c"" name=""$(ConvertTo-XlsxXmlText $headers[$c - 1])""/>")
+                    }
+                    [void]$table.Append('</tableColumns><tableStyleInfo name="RjRbReport" showFirstColumn="0" showLastColumn="0" showRowStripes="1" showColumnStripes="0"/></table>')
+                    & $writeEntry "xl/tables/table$s.xml" $table.ToString()
+
+                    # Sheet relationships: rId1 = table, rId2+ = external hyperlink targets
+                    $sheetRels = [System.Text.StringBuilder]::new()
+                    [void]$sheetRels.Append("$xmlDecl<Relationships xmlns=""$pkgRelNs"">")
+                    [void]$sheetRels.Append("<Relationship Id=""rId1"" Type=""$relNs/table"" Target=""../tables/table$s.xml""/>")
+                    $linkId = 1
+                    foreach ($link in $hyperlinks) {
+                        $linkId++
+                        [void]$sheetRels.Append("<Relationship Id=""rId$linkId"" Type=""$relNs/hyperlink"" Target=""$(ConvertTo-XlsxXmlText $link.Url)"" TargetMode=""External""/>")
+                    }
+                    [void]$sheetRels.Append('</Relationships>')
+                    & $writeEntry "xl/worksheets/_rels/sheet$s.xml.rels" $sheetRels.ToString()
+                }
+                #endregion
+
+                [void]$contentTypes.Append('</Types>')
+                & $writeEntry '[Content_Types].xml' $contentTypes.ToString()
+            }
+            finally {
+                $zip.Dispose()
+            }
+        }
+        finally {
+            $fileStream.Dispose()
+        }
+
+        Write-Verbose "Export-RjRbXlsx: wrote $($sheetDefs.Count) worksheet(s) to $Path"
+    }
+}

--- a/MailReport.ps1
+++ b/MailReport.ps1
@@ -93,6 +93,40 @@ function Resolve-RjRbImageSource {
     }
 }
 
+function Add-RjRbCellSoftBreaks {
+    <#
+        .SYNOPSIS
+        Inserts zero-width-space break opportunities into overlong unbreakable
+        table-cell tokens.
+
+        .DESCRIPTION
+        The Outlook Classic (Word) engine does not break long words inside
+        table cells; a single unbreakable token wider than its column makes
+        Word grow the whole table - and with it the fixed 750px email card -
+        past the header/footer banners. This helper inserts U+200B zero-width
+        spaces every 10 characters into runs of 30+ characters that contain no
+        natural break points (. @ / - &). Word and modern clients treat U+200B
+        as an invisible line-break opportunity. Only text nodes are touched -
+        never markup, attributes or URLs. Trade-off: copying such a
+        (pathological) value out of the mail includes the invisible U+200B
+        characters; realistic serials, device names, mail addresses and URLs
+        stay untouched because they are either shorter than 30 characters or
+        wrap naturally at their punctuation.
+    #>
+    param([string]$Html)
+    if ([string]::IsNullOrEmpty($Html)) { return $Html }
+    return [regex]::Replace($Html, '(?<=^|>)[^<>]+(?=<|$)', {
+        param($m)
+        [regex]::Replace($m.Value, '[^\s<>&.@/\-]{30,}', {
+            param($t)
+            # 10-char chunks (~70px at 14px font) fit even the narrowest
+            # generated column, so Word never needs to grow the table
+            $chunks = [regex]::Matches($t.Value, '.{1,10}') | ForEach-Object { $_.Value }
+            [string]::Join([string][char]0x200B, $chunks)
+        })
+    })
+}
+
 function ConvertFrom-RjRbMarkdownToHtml {
     <#
         .SYNOPSIS
@@ -159,9 +193,11 @@ function ConvertFrom-RjRbMarkdownToHtml {
 
         # Wrap in MSO-only table to add horizontal inset in Outlook Classic
         # (Word engine ignores border-radius, so without this the bg fills edge-to-edge)
-        # Use <pre> inside the td to preserve line breaks in Outlook Classic
-        $msoCode = $code -replace "`n", "`n"
-        $htmlBlock = "<!--[if mso]><table role=`"presentation`" width=`"100%`" cellpadding=`"0`" cellspacing=`"0`" border=`"0`" style=`"margin:20px 0;border-collapse:collapse;`"><tr><td bgcolor=`"#e8ebed`" style=`"background-color:#e8ebed;border:1px solid #e5e7eb;padding:20px;`"><pre style=`"margin:0;font-family:Consolas,'Courier New',monospace;font-size:13px;color:#011e33;white-space:pre;`">$msoCode</pre></td></tr></table><![endif]--><!--[if !mso]><!-->$preTag<!--<![endif]-->"
+        # Use <pre> inside the td to preserve line breaks in Outlook Classic.
+        # table-layout:fixed pins the table to the container width (Word's automatic
+        # layout would grow it to fit the longest code line); white-space:pre-wrap asks
+        # Word to wrap long lines instead of clipping them at the fixed cell edge.
+        $htmlBlock = "<!--[if mso]><table role=`"presentation`" width=`"100%`" cellpadding=`"0`" cellspacing=`"0`" border=`"0`" style=`"margin:20px 0;width:100%;table-layout:fixed;border-collapse:collapse;`"><tr><td bgcolor=`"#e8ebed`" style=`"background-color:#e8ebed;border:1px solid #e5e7eb;padding:20px;`"><pre style=`"margin:0;font-family:Consolas,'Courier New',monospace;font-size:13px;color:#011e33;white-space:pre-wrap;`">$code</pre></td></tr></table><![endif]--><!--[if !mso]><!-->$preTag<!--<![endif]-->"
 
         $placeholder = "§CODEBLOCK§$codeBlockIndex§"
         $codeBlocks += $htmlBlock
@@ -210,7 +246,7 @@ function ConvertFrom-RjRbMarkdownToHtml {
             elseif ($i -eq 0) { 'padding:0 6px 0 0;' }
             elseif ($i -eq ($count - 1)) { 'padding:0 0 0 6px;' }
             else { 'padding:0 6px;' }
-            $msoCells.Add("<td width=`"$cellPercent%`" valign=`"top`" style=`"${msoPad}border:none;background:none;`"><table role=`"presentation`" width=`"100%`" cellpadding=`"0`" cellspacing=`"0`" border=`"0`" style=`"width:100%;$tableReset`"><tr><td bgcolor=`"#f8842c`" align=`"center`" valign=`"middle`" style=`"mso-padding-alt:14px 8px;padding:14px 8px;border:none;`"><a href=`"$href`" style=`"font-family:'Segoe UI',Arial,sans-serif;font-size:16px;font-weight:bold;line-height:16px;color:#ffffff;text-decoration:none;mso-line-height-rule:exactly;`">$label</a></td></tr></table></td>")
+            $msoCells.Add("<td width=`"$cellPercent%`" valign=`"top`" style=`"${msoPad}border:none;background:none;`"><table role=`"presentation`" width=`"100%`" cellpadding=`"0`" cellspacing=`"0`" border=`"0`" style=`"width:100%;table-layout:fixed;$tableReset`"><tr><td bgcolor=`"#f8842c`" align=`"center`" valign=`"middle`" style=`"mso-padding-alt:14px 8px;padding:14px 8px;border:none;`"><a href=`"$href`" style=`"font-family:'Segoe UI',Arial,sans-serif;font-size:16px;font-weight:bold;line-height:16px;color:#ffffff;text-decoration:none;mso-line-height-rule:exactly;`">$label</a></td></tr></table></td>")
 
             # Modern clients support flexible button widths and rounded corners. 
             # Render buttons as links with padding and background color, wrapped in a flex container to allow wrapping if there are many buttons or the labels are long.
@@ -219,7 +255,7 @@ function ConvertFrom-RjRbMarkdownToHtml {
 
         # Outlook Classic (Word engine) requires tables for complex layouts, so render buttons in a table row with one cell per button.
         # Use a nested table for the button styling to prevent Word from stripping styles on the outer cell.
-        $msoRow = "<!--[if mso]><table role=`"presentation`" width=`"100%`" cellpadding=`"0`" cellspacing=`"0`" border=`"0`" style=`"width:100%;$tableReset`"><tr>$([string]::Join('', $msoCells))</tr></table><![endif]-->"
+        $msoRow = "<!--[if mso]><table role=`"presentation`" width=`"100%`" cellpadding=`"0`" cellspacing=`"0`" border=`"0`" style=`"width:100%;table-layout:fixed;$tableReset`"><tr>$([string]::Join('', $msoCells))</tr></table><![endif]-->"
         # Modern email clients support more flexible layouts and better CSS support, so render buttons as styled links in a flex container that allows wrapping if needed.
         $webRow = "<!--[if !mso]><!--><div style=`"display:flex;flex-wrap:wrap;margin:-6px;`">$([string]::Join('', $webButtons))</div><!--<![endif]-->"
         $row = "$msoRow$webRow"
@@ -237,7 +273,7 @@ function ConvertFrom-RjRbMarkdownToHtml {
     # (border-radius/box-shadow/background -> rounded pill) and .content td
     # (border-bottom -> a second line), so both are reset inline (inline beats the
     # class selectors). Modern clients ignore the mso branch and use the plain <hr>.
-    $html = $html -replace '(?m)^(-{3,}|\*{3,}|_{3,})$', '<!--[if mso]><table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:16px 0;border:0;border-collapse:collapse;background:transparent;mso-table-lspace:0pt;mso-table-rspace:0pt;"><tr><td style="border:0;border-top:2px solid #e5e7eb;font-size:0;line-height:0;mso-line-height-rule:exactly;background:transparent;">&nbsp;</td></tr></table><![endif]--><!--[if !mso]><!--><hr style="border:0;border-top:2px solid #e5e7eb;margin:16px 0;" /><!--<![endif]-->'
+    $html = $html -replace '(?m)^(-{3,}|\*{3,}|_{3,})$', '<!--[if mso]><table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:16px 0;width:100%;table-layout:fixed;border:0;border-collapse:collapse;background:transparent;mso-table-lspace:0pt;mso-table-rspace:0pt;"><tr><td style="border:0;border-top:2px solid #e5e7eb;font-size:0;line-height:0;mso-line-height-rule:exactly;background:transparent;">&nbsp;</td></tr></table><![endif]--><!--[if !mso]><!--><hr style="border:0;border-top:2px solid #e5e7eb;margin:16px 0;" /><!--<![endif]-->'
 
     # Headers (all 6 levels) - now safe from code block interference
     # Also supports headers without space after # (e.g., #Header instead of # Header)
@@ -379,7 +415,7 @@ function ConvertFrom-RjRbMarkdownToHtml {
                     }
                     # Same MSO/non-MSO wrapper pattern as a plain blockquote, but
                     # no italics and a per-type accent colour on the left border.
-                    $processedLines += "<!--[if mso]><table role=`"presentation`" width=`"100%`" cellpadding=`"0`" cellspacing=`"0`" border=`"0`" style=`"margin:15px 0;`"><tr><td bgcolor=`"#e8ebed`" style=`"background-color:#e8ebed;border-left:4px solid $($palette.Accent);padding:10px 24px;color:#374151;`" valign=`"top`"><![endif]-->"
+                    $processedLines += "<!--[if mso]><table role=`"presentation`" width=`"100%`" cellpadding=`"0`" cellspacing=`"0`" border=`"0`" style=`"margin:15px 0;width:100%;table-layout:fixed;`"><tr><td bgcolor=`"#e8ebed`" style=`"background-color:#e8ebed;border-left:4px solid $($palette.Accent);padding:10px 24px;color:#374151;`" valign=`"top`"><![endif]-->"
                     $processedLines += "<!--[if !mso]><!--><blockquote style=`"border-left:4px solid $($palette.Accent);background-color:#e8ebed;padding:10px 24px;margin:15px 0;color:#374151;border-radius:0 8px 8px 0;`"><!--<![endif]-->"
                     $processedLines += "<p style=`"margin:0 0 8px 0;font-weight:700;color:$($palette.Accent);font-size:14px;`">$($palette.Glyph) $($palette.Title)</p>"
                     $inBlockquote = $true
@@ -389,7 +425,7 @@ function ConvertFrom-RjRbMarkdownToHtml {
                 # MSO-only table wrapper for blockquote background (Word engine ignores background-color on blockquote)
                 # Use border-left on a single td rather than a separate narrow td (Outlook enforces min cell width)
                 # Hide the <blockquote> from MSO so only the table renders (inline styles override !important in Word engine)
-                $processedLines += '<!--[if mso]><table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:15px 0;"><tr><td bgcolor="#e8ebed" style="background-color:#e8ebed;border-left:4px solid #3b82f6;padding:0 24px;font-style:italic;color:#374151;" valign="top"><![endif]-->'
+                $processedLines += '<!--[if mso]><table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:15px 0;width:100%;table-layout:fixed;"><tr><td bgcolor="#e8ebed" style="background-color:#e8ebed;border-left:4px solid #3b82f6;padding:0 24px;font-style:italic;color:#374151;" valign="top"><![endif]-->'
                 $processedLines += '<!--[if !mso]><!--><blockquote style="border-left:4px solid #3b82f6;background-color:#e8ebed;padding:10px 24px;margin:15px 0;font-style:italic;color:#374151;"><!--<![endif]-->'
                 $inBlockquote = $true
             }
@@ -413,6 +449,77 @@ function ConvertFrom-RjRbMarkdownToHtml {
                 $inTable = $true
                 $tableRowIndex = 0
 
+                # Outlook Classic renders this table with table-layout:fixed (MSO style
+                # block backstop), which defaults to EQUAL column widths - a short
+                # column (date) would wrap while a long column wastes space. In fixed
+                # layout Word takes column widths from <col> elements, and the
+                # converter sees every cell up front - so scan the whole table ahead
+                # and emit an MSO-only <col> set with content-proportional widths.
+                # Modern clients skip the conditional comment and keep auto layout.
+                $colMaxChars = [System.Collections.Generic.List[int]]::new()
+                for ($la = $i; $la -lt $lineCount -and $lines[$la] -match '^\|.*\|$'; $la++) {
+                    if ($lines[$la] -match '^\|[-:\s\|]+\|$') { continue }   # alignment separator row
+                    $laCells = ($lines[$la] -replace '^\|', '' -replace '\|$', '').Split('|')
+                    for ($lc = 0; $lc -lt $laCells.Count; $lc++) {
+                        # Visible-length estimate: resolve inline-code placeholders to
+                        # their real text, strip html tags (links/bold are converted by
+                        # now), count entities and escaped pipes as one character.
+                        $visible = $laCells[$lc].Trim()
+                        $visible = $visible -replace '§INLINECODE§(\d+)§', { 'x' * (($inlineCodeBlocks[[int]$_.Groups[1].Value] -replace '<[^>]+>', '').Length) }
+                        $visible = $visible -replace '<[^>]+>', '' -replace '§ESCAPEDPIPE§|&[A-Za-z]+;|&#\d+;', 'x' -replace '§ESCAPED§', ''
+                        while ($colMaxChars.Count -le $lc) { $colMaxChars.Add(0) }
+                        if ($visible.Length -gt $colMaxChars[$lc]) { $colMaxChars[$lc] = $visible.Length }
+                    }
+                }
+                $tableColPcts = @()
+                $tableColPctsPending = $false
+                if ($colMaxChars.Count -ge 2) {
+                    # Pixel need per column: clamped char count x ~7px (14px
+                    # proportional font) plus the 2x16px cell padding. Distribute the
+                    # ~650px content width max-min fair: every column that fits keeps
+                    # exactly its need (dates never wrap), oversized columns split the
+                    # remainder equally among themselves.
+                    $colPxNeed = @($colMaxChars | ForEach-Object { [Math]::Min([Math]::Max($_, 3), 60) * 7 + 32 })
+                    $colPx = @(0.0) * $colPxNeed.Count
+                    $avail = 650.0
+                    $active = @(0..($colPxNeed.Count - 1))
+                    while ($active.Count -gt 0) {
+                        $fair = $avail / $active.Count
+                        $fits = @($active | Where-Object { $colPxNeed[$_] -le $fair })
+                        if ($fits.Count -eq 0) { foreach ($ci in $active) { $colPx[$ci] = $fair }; break }
+                        foreach ($ci in $fits) { $colPx[$ci] = $colPxNeed[$ci]; $avail -= $colPxNeed[$ci] }
+                        $active = @($active | Where-Object { $colPxNeed[$_] -gt $fair })
+                    }
+                    # Integer percentages summing to exactly 100 (largest remainder;
+                    # a sub-650px total just scales up proportionally via the divide).
+                    # The widths are applied as inline style="width:N%" on the cells
+                    # of the table's FIRST row (below) - NOT as <col>/<colgroup>
+                    # elements: Word's HTML reader keeps only the first column
+                    # element of a run and foster-parents the rest into the first
+                    # header cell, silently dropping their widths. Verified three
+                    # times via Outlook's save-as-HTML output (bare <col/> run,
+                    # [if mso]-wrapped <colgroup>, and a plain unconditional
+                    # <colgroup> all got relocated). Inline cell widths are Word's
+                    # own native format and are applied reliably; Word uses them as
+                    # its fixed column grid and wraps long tokens inside the cell
+                    # instead of growing the table past the 750px card. Modern
+                    # clients treat them as proportional hints in auto layout
+                    # (deliberate, minor rendering change - the proportions are
+                    # derived from the same cell contents auto layout would
+                    # measure), and .table-wrapper keeps its horizontal scroll on
+                    # small screens.
+                    $pxSum = ($colPx | Measure-Object -Sum).Sum
+                    $raw = @($colPx | ForEach-Object { 100.0 * $_ / $pxSum })
+                    $pct = @($raw | ForEach-Object { [int][Math]::Floor($_) })
+                    $rest = 100 - ($pct | Measure-Object -Sum).Sum
+                    foreach ($ci in (0..($raw.Count - 1) | Sort-Object { [Math]::Floor($raw[$_]) - $raw[$_] })) {
+                        if ($rest -le 0) { break }
+                        $pct[$ci]++; $rest--
+                    }
+                    $tableColPcts = $pct
+                    $tableColPctsPending = $true
+                }
+
                 # Check for separator line with alignment
                 if (($i + 1) -lt $lineCount -and $lines[$i + 1] -match '^\|[-:\s\|]+\|$') {
                     $separatorLine = $lines[$i + 1]
@@ -431,12 +538,16 @@ function ConvertFrom-RjRbMarkdownToHtml {
                     if ($cells.Count -gt 0) {
                         $processedLines += '<thead><tr bgcolor="#f8842c" style="background-color:#f8842c;">'
                         for ($j = 0; $j -lt $cells.Count; $j++) {
-                            $cleanCell = $cells[$j].Trim()
+                            $cleanCell = Add-RjRbCellSoftBreaks -Html $cells[$j].Trim()
                             if ([string]::IsNullOrWhiteSpace($cleanCell)) { $cleanCell = '&nbsp;' }
                             $alignClass = if ($j -lt $tableAlignments.Count -and $tableAlignments[$j]) { " class=`"text-$($tableAlignments[$j])`"" } else { "" }
-                            $processedLines += "<th$alignClass style=`"background-color:#f8842c;color:#ffffff;padding:8px 16px;font-weight:600;font-size:14px;`">$cleanCell</th>"
+                            # width:N% first in the style attr - the header row defines
+                            # Word's column grid (see width computation comment above)
+                            $widthStyle = if ($tableColPctsPending -and $j -lt $tableColPcts.Count) { "width:$($tableColPcts[$j])%;" } else { '' }
+                            $processedLines += "<th$alignClass style=`"${widthStyle}background-color:#f8842c;color:#ffffff;padding:8px 16px;font-weight:600;font-size:14px;`">$cleanCell</th>"
                         }
                         $processedLines += '</tr></thead><tbody>'
+                        $tableColPctsPending = $false
                         $i++
                         continue
                     }
@@ -450,13 +561,17 @@ function ConvertFrom-RjRbMarkdownToHtml {
                 $rowBgAttr = if ($tableRowIndex % 2 -eq 0) { ' bgcolor="#e8ebed" style="background-color:#e8ebed;"' } else { '' }
                 $processedLines += "<tr$rowBgAttr>"
                 for ($j = 0; $j -lt $cells.Count; $j++) {
-                    $cleanCell = $cells[$j].Trim()
+                    $cleanCell = Add-RjRbCellSoftBreaks -Html $cells[$j].Trim()
                     if ([string]::IsNullOrWhiteSpace($cleanCell)) { $cleanCell = '&nbsp;' }
                     $alignStyle = if ($j -lt $tableAlignments.Count -and $tableAlignments[$j]) { "text-align:$($tableAlignments[$j]);" } else { "" }
                     $alignClass = if ($j -lt $tableAlignments.Count -and $tableAlignments[$j]) { " class=`"text-$($tableAlignments[$j])`"" } else { "" }
-                    $processedLines += "<td$alignClass style=`"padding:8px 16px;border-bottom:1px solid #e8ebed;font-size:14px;color:#2D3748;${alignStyle}`">$cleanCell</td>"
+                    # Only set for the first row of a headerless table (no separator
+                    # line): that row then defines Word's column grid instead of a thead
+                    $widthStyle = if ($tableColPctsPending -and $j -lt $tableColPcts.Count) { "width:$($tableColPcts[$j])%;" } else { '' }
+                    $processedLines += "<td$alignClass style=`"${widthStyle}padding:8px 16px;border-bottom:1px solid #e8ebed;font-size:14px;color:#2D3748;${alignStyle}`">$cleanCell</td>"
                 }
                 $processedLines += '</tr>'
+                $tableColPctsPending = $false
             }
         }
         # Unordered List processing
@@ -491,7 +606,12 @@ function ConvertFrom-RjRbMarkdownToHtml {
                     # border-collapse + explicit border:0 on every cell is
                     # required - Outlook New otherwise paints faint default
                     # cell borders even with border="0" on the table.
-                    $processedLines += '<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:15px 0 12px 20px;border-collapse:collapse;border:0;background:transparent;">'
+                    # table-layout:auto is a no-op in modern clients (a widthless table
+                    # computes as auto layout anyway) but shields this table from the
+                    # MSO-block "table { table-layout:fixed }" backstop in Outlook
+                    # Classic, which would otherwise freeze the glyph column at the
+                    # width of the first row.
+                    $processedLines += '<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:15px 0 12px 20px;border-collapse:collapse;border:0;background:transparent;table-layout:auto;">'
                     $inTaskTable = $true
                 }
 
@@ -671,19 +791,20 @@ function ConvertFrom-RjRbMarkdownToHtml {
     $html = $html -replace '§ESCAPEDPIPE§', '|'
     $html = $html -replace '§ESCAPED§(.{1})§ESCAPED§', '$1'
 
-    # Restore inline code blocks from placeholders
+    # Restore protected blocks from placeholders. String.Replace, NOT -replace:
+    # the stored fragments are user content, and regex substitution would treat
+    # $-sequences in them as substitution tokens ($_ = whole input, $& = match,
+    # $1 = group), duplicating the entire document or corrupting the output.
     for ($i = 0; $i -lt $inlineCodeBlocks.Count; $i++) {
-        $html = $html -replace "§INLINECODE§$i§", $inlineCodeBlocks[$i]
+        $html = $html.Replace("§INLINECODE§$i§", $inlineCodeBlocks[$i])
     }
 
-    # Restore code blocks from placeholders
     for ($i = 0; $i -lt $codeBlocks.Count; $i++) {
-        $html = $html -replace "§CODEBLOCK§$i§", $codeBlocks[$i]
+        $html = $html.Replace("§CODEBLOCK§$i§", $codeBlocks[$i])
     }
 
-    # Restore link button rows from placeholders
     for ($i = 0; $i -lt $buttonRows.Count; $i++) {
-        $html = $html -replace "§BUTTONROW§$i§", $buttonRows[$i]
+        $html = $html.Replace("§BUTTONROW§$i§", $buttonRows[$i])
     }
 
     return $html
@@ -1117,23 +1238,24 @@ function Get-RjRbReportEmailBody {
         .email-container { max-width: 750px; }
     }
 
-    /* === DARK MODE (Outlook Classic Win32 only) ===
-       Outlook Classic ignores @media (prefers-color-scheme) and instead
-       auto-inverts light backgrounds at render time, annotating the
-       inverted elements with the proprietary attributes [data-ogsb]
-       (background) and [data-ogsc] (color). Outlook New / OWA / Apple
-       Mail / Gmail do NOT set these attributes — they use the
-       prefers-color-scheme block below. So these selectors target
-       Outlook Classic Dark Mode exclusively, without affecting any
-       other client. !important is required because Outlook's inversion
-       writes inline style attributes onto the element that would
-       otherwise win on specificity. Colors mirror the
-       prefers-color-scheme block so Classic and New look identical.
-       For these selectors to match, the target element must carry an
-       INLINE background-color (or bgcolor attribute) in the source —
-       Outlook only injects data-ogsb where it actually inverted an
-       explicit inline value. That is why body / .email-container /
-       .content carry inline bgcolor/background-color below. */
+    /* === DARK MODE ([data-ogsb]/[data-ogsc] annotations) ===
+       These attributes are injected by the Outlook.com / OWA / New Outlook
+       dark-mode transform - NOT by Outlook Classic. The Word engine
+       re-colors internally at render time without touching the DOM and does
+       not support attribute selectors at all, so these rules can only ever
+       match in the web/New Outlook renderers, as a counterweight to their
+       color inversion. A selector only matches where the transform actually
+       inverted an explicit inline background (bgcolor attribute or inline
+       background-color); elements without one (body, .email-container,
+       .content) never receive data-ogsb, so those selectors below are inert
+       today - kept for parity should the markup ever gain inline
+       backgrounds. Do NOT add inline backgrounds to body/.email-container
+       just to activate them: Gmail re-interprets body-level backgrounds and
+       could tint the whole page. Outlook Classic dark mode simply
+       auto-inverts our inline bgcolors (acceptable; the light VML page
+       background around the inverted card remains - known cosmetic
+       mismatch, out of scope). !important is required because the dark-mode
+       transform writes inline styles that would otherwise win. */
     body[data-ogsb] { background-color: #1a1a1a !important; }
 
     .email-container[data-ogsb],
@@ -1219,44 +1341,45 @@ function Get-RjRbReportEmailBody {
 <!-- Outlook Classic Fixes (only for MSO) -->
 <!--[if mso]>
 <style type="text/css">
-    /* Force Light Mode for Outlook Classic */
-    body { background-color: #e8ebed; }
+    /* Force Light Mode for Outlook Classic. The surround is deliberately
+       WHITE here (not #e8ebed like modern clients): Word lays the mail out
+       on its Letter page model (~627px usable), so the 750px card overflows
+       the page to the right - a tiled grey background would only cover the
+       page area and leave a white strip beside the card (patchwork effect).
+       A uniform white surround with the card's 1px border looks clean;
+       centering is impossible in Classic for the same reason (card wider
+       than Word's page content area). Modern clients keep the grey,
+       centered layout from the main style block. */
+    body { background-color: #ffffff; }
     .email-container { background-color: #ffffff; width: 750px; }
-    .content { background-color: #ffffff; mso-padding-alt: 48px; }
+    /* padding:0 - the MSO inner wrapper td carries the 48px content padding;
+       Word builds that honor div padding would otherwise double it to 96px. */
+    .content { background-color: #ffffff; padding: 0; }
 
     /* MSO Font Fallback - Outlook Classic cannot load Google Fonts */
     body, p, li, td, th, h1, h2, h3, h4, h5, h6, div, span, a, blockquote {
         font-family: 'Segoe UI', Arial, Helvetica, sans-serif !important;
     }
 
-    /* MSO Table Fixes */
-    table { mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse; }
-
-    /* MSO Table Layout Fix - the Word engine uses automatic table layout
-       and grows a table to fit its widest cell, ignoring width="100%".
-       A wide data table therefore stretches the .content cell, which
-       stretches the fixed 750px .email-container past the fixed-width
-       header <img>, leaving an empty strip beside the header graphic.
-       Forcing fixed layout makes the Word engine honor the table's width
-       against its container and wrap long cell values instead of growing.
-       Scoped to .content so the outer 750px container table is untouched;
-       modern clients keep their .table-wrapper overflow-x scroll behaviour
-       because this lives in the MSO-only conditional block. */
-    .content table {
-        table-layout: fixed !important;
-        width: 100% !important;
-    }
-    .content th, .content td {
-        word-break: break-word;
-        overflow-wrap: break-word;
-        word-wrap: break-word;
-    }
-
-    /* MSO Line Height Fix */
-    .content p, .content li, .content td, .content th {
-        mso-line-height-rule: exactly;
-        line-height: 1.6;
-    }
+    /* MSO Table Fixes + width lock backstop.
+       The Word engine uses automatic table layout and grows a table to fit
+       its widest cell, ignoring width="100%". A wide table would stretch the
+       .content cell and push the card past the fixed-width 750px header and
+       footer images, leaving an empty strip beside them. table-layout:fixed
+       makes Word honor declared widths and wrap long cell values natively at
+       the cell boundary (word-break/overflow-wrap CSS are no-ops in Word -
+       fixed layout is the actual wrapping mechanism).
+       IMPORTANT: Word applies element and class selectors reliably, but
+       descendant selectors like ".content table" only unreliably - never
+       hang critical rules on a descendant selector in this block. The
+       critical layers are the inline table-layout:fixed styles on the outer
+       750px wrapper, the inner content wrapper and every MSO-only twin
+       table; the two rules below are the backstop for the markdown data
+       tables (class "table") and for any table inside caller-supplied
+       HtmlContent. A table that must keep automatic layout opts out via
+       inline table-layout:auto (see the task-list table). */
+    table { mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse; table-layout: fixed; }
+    .table { table-layout: fixed; }
 
     /* MSO Heading Spacing - Word engine uses its own spacing without these */
     h1 { mso-margin-top-alt: 0; mso-margin-bottom-alt: 15px; mso-line-height-rule: exactly; }
@@ -1267,10 +1390,9 @@ function Get-RjRbReportEmailBody {
     /* MSO Paragraph Spacing */
     p { mso-margin-top-alt: 0; mso-margin-bottom-alt: 15px; }
 
-    /* MSO Container Width Fix */
-    .email-container { width: 750px !important; }
-
-    /* MSO tenant-info / attachments box - table wrapper handles styling, suppress on div */
+    /* MSO tenant-info / attachments box - table wrapper handles styling, suppress on div.
+       Dead for module-generated mail (these divs exist only in non-mso branches) -
+       kept as insurance for caller-supplied HtmlContent. */
     .tenant-info, .attachments {
         border: none !important;
         border-left: none !important;
@@ -1302,7 +1424,6 @@ function Get-RjRbReportEmailBody {
     .content li {
         margin-left: 0;
         padding-left: 8px;
-        mso-list: l0 level1 lfo1;
     }
 
     /* MSO HR Fix */
@@ -1312,29 +1433,26 @@ function Get-RjRbReportEmailBody {
 <![endif]-->
 </head>
 <body>
-    <!--[if mso]>
-    <v:background xmlns:v="urn:schemas-microsoft-com:vml" fill="t">
-        <v:fill type="tile" color="#e8ebed"/>
-    </v:background>
-    <![endif]-->
 
     <!--[if mso]>
-    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="750" align="center" style="width:750px;border-collapse:collapse;">
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="750" align="center" style="width:750px;table-layout:fixed;border-collapse:collapse;">
     <tr>
-    <td style="background-color:#ffffff;border:1px solid #d1d5db;">
+    <td width="750" style="width:750px;background-color:#ffffff;border:1px solid #d1d5db;">
     <![endif]-->
     <div class="email-container">
         $(if ($IncludeHeader) {
             @"
         <div class='header'>
-            <img class='header-img' src='cid:header' alt='$HeaderAltText' width='750' />
+            <!-- keep src/alt/width of the mso and non-mso img in sync -->
+            <!--[if mso]><img src='cid:header' alt='$HeaderAltText' width='750' style='width:750px;display:block;border:0;' /><![endif]-->
+            <!--[if !mso]><!--><img class='header-img' src='cid:header' alt='$HeaderAltText' width='750' /><!--<![endif]-->
         </div>
 "@
         })
 
         <div class="content">
             <!--[if mso]>
-            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="width:100%;table-layout:fixed;border-collapse:collapse;">
             <tr>
             <td style="padding:48px;">
             <![endif]-->
@@ -1344,7 +1462,7 @@ function Get-RjRbReportEmailBody {
             $(if ($IncludeTenantInfo) {
                 @'
             <!--[if mso]>
-            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin-top:32px;border-collapse:collapse;"><tr>
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin-top:32px;width:100%;table-layout:fixed;border-collapse:collapse;"><tr>
             <td bgcolor="#e8ebed" style="background-color:#e8ebed;border-left:4px solid #f8842c;padding:6px 20px;font-size:14px;" valign="top">
             <![endif]-->
             <!--[if !mso]><!-->
@@ -1382,8 +1500,8 @@ function Get-RjRbReportEmailBody {
             @"
 
             <!--[if mso]>
-            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"><tr><td style="font-size:1px;line-height:16px;height:16px;">&nbsp;</td></tr></table>
-            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="border-collapse:collapse;"><tr>
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="width:100%;table-layout:fixed;"><tr><td style="font-size:1px;line-height:16px;height:16px;">&nbsp;</td></tr></table>
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="width:100%;table-layout:fixed;border-collapse:collapse;"><tr>
             <td bgcolor="#e8ebed" style="background-color:#e8ebed;border-left:4px solid #f8842c;padding:6px 20px;font-size:14px;" valign="top">
             <![endif]-->
             <!--[if !mso]><!-->
@@ -1413,7 +1531,9 @@ function Get-RjRbReportEmailBody {
             @"        
         <div class="footer">
             <a href="$FooterLink" target="_blank" title="Visit $FooterLink" style="display:block;border:0;outline:none;text-decoration:none;">
-                <img class="footer-img" src="cid:footer" alt="$FooterAltText" width="750" border="0" style="display:block;width:100%;max-width:750px;height:auto;border:0;outline:none;text-decoration:none;" />
+                <!-- keep src/alt/width of the mso and non-mso img in sync -->
+                <!--[if mso]><img src="cid:footer" alt="$FooterAltText" width="750" border="0" style="width:750px;display:block;border:0;" /><![endif]-->
+                <!--[if !mso]><!--><img class="footer-img" src="cid:footer" alt="$FooterAltText" width="750" border="0" style="display:block;width:100%;max-width:750px;height:auto;border:0;outline:none;text-decoration:none;" /><!--<![endif]-->
             </a>
         </div>
 "@

--- a/RealmJoin.RunbookHelper.psd1
+++ b/RealmJoin.RunbookHelper.psd1
@@ -2,7 +2,7 @@
 
 @{
     RootModule        = 'RealmJoin.RunbookHelper.psm1'
-    ModuleVersion     = '0.8.7'
+    ModuleVersion     = '0.8.8'
     GUID              = '50c59179-6cb8-4968-bf76-e7de04f02957'
     Author            = 'glueckkanja AG'
     CompanyName       = 'glueckkanja AG'
@@ -18,7 +18,7 @@
         'Connect-RjRbAzAccount', 'Connect-RjRbAzureAD', 'Get-RjRbAzureADTenantDetail', 'Connect-RjRbExchangeOnline',
         'Connect-RjRbGraph', 'Connect-RjRbDefenderATP', 'Send-RjRbReportEmail',
         'ConvertFrom-RjRbMarkdownToHtml', 'Get-RjRbReportEmailBody', 'Resolve-RjRbImageSource',
-        'Publish-RjRbFilesToStorageContainer',
+        'Publish-RjRbFilesToStorageContainer', 'Export-RjRbXlsx',
         'Publish-RjRbKeyVaultSecret', 'Publish-RjRbKeyVaultKey', 'Publish-RjRbKeyVaultCertificate'
     )
     CmdletsToExport   = @()
@@ -37,6 +37,7 @@
         'Logging.ps1',
         'MailReport.ps1',
         'FileReport.ps1',
+        'ExcelReport.ps1',
         'KeyVault.ps1',
         'Rest.ps1',
         'Assets\Header.png',

--- a/RealmJoin.RunbookHelper.psm1
+++ b/RealmJoin.RunbookHelper.psm1
@@ -39,4 +39,5 @@ else {
 . $PSScriptRoot\Rest.ps1
 . $PSScriptRoot\MailReport.ps1
 . $PSScriptRoot\FileReport.ps1
+. $PSScriptRoot\ExcelReport.ps1
 . $PSScriptRoot\KeyVault.ps1


### PR DESCRIPTION
This pull request makes several improvements to the Markdown-to-HTML email rendering in `MailReport.ps1`, focusing on better compatibility with Outlook Classic (Word engine), enhanced table and button rendering, and improved safety and readability for long unbreakable strings in table cells.

**Table rendering improvements:**

* Tables now use proportional column widths in Outlook Classic by analyzing cell content and applying calculated inline `width:N%` styles to header or first-row cells, ensuring better layout and preventing table overflow. [[1]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fR452-R522) [[2]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fL434-R550) [[3]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fL453-R574)
* Long unbreakable tokens in table cells are automatically softened with zero-width space break opportunities, preventing layout breakage in Outlook Classic. [[1]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fR96-R129) [[2]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fL434-R550) [[3]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fL453-R574)
* All MSO-specific tables (code blocks, buttons, blockquotes, horizontal rules) now consistently use `table-layout:fixed` and inline `width:100%` for predictable rendering in Outlook Classic. [[1]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fL162-R200) [[2]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fL213-R249) [[3]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fL222-R258) [[4]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fL240-R276) [[5]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fL382-R418) [[6]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fL392-R428)

**Button and blockquote rendering:**

* Button rows and blockquotes use improved table markup with fixed layout for Outlook Classic, ensuring correct sizing and appearance regardless of content. [[1]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fL213-R249) [[2]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fL222-R258) [[3]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fL382-R418) [[4]](diffhunk://#diff-da5a03483d74d2c18967cf6d869c974e06127619ea41144ceea009a5b00ef09fL392-R428)

**Code block and placeholder safety:**

* Restoring code blocks, inline code, and button rows from placeholders now uses `String.Replace` instead of regex, preventing corruption if user content contains ` sequences.

**Other rendering fixes:**

* Task tables now explicitly use `table-layout:auto` to avoid unwanted fixed layout in Outlook Classic.

These changes collectively make Markdown emails more robust and visually consistent across both modern and legacy Outlook clients.